### PR TITLE
feat: refactor order business logic across multiple files

### DIFF
--- a/adapter/order/restful/wire.go
+++ b/adapter/order/restful/wire.go
@@ -49,6 +49,7 @@ var providerSet = wire.NewSet(
 
 	biz.NewOrderBiz,
 	biz2.NewRestaurantHTTPClient,
+	biz2.NewMenuHTTPClient,
 	biz3.NewUserHTTPClient,
 	order.NewMongodb,
 	mongodbx.NewClient,

--- a/adapter/order/restful/wire_gen.go
+++ b/adapter/order/restful/wire_gen.go
@@ -35,13 +35,14 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 		return nil, err
 	}
 	iRestaurantBiz := biz.NewRestaurantHTTPClient()
+	iMenuBiz := biz.NewMenuHTTPClient()
 	iUserBiz := biz2.NewUserHTTPClient()
 	client, err := mongodbx.NewClient(application)
 	if err != nil {
 		return nil, err
 	}
 	iOrderRepo := order.NewMongodb(client)
-	iOrderBiz := biz3.NewOrderBiz(iRestaurantBiz, iUserBiz, iOrderRepo)
+	iOrderBiz := biz3.NewOrderBiz(iRestaurantBiz, iMenuBiz, iUserBiz, iOrderRepo)
 	injector := &wirex.Injector{
 		A:            application,
 		OrderService: iOrderBiz,
@@ -76,5 +77,5 @@ func initApplication() (*configx.Application, error) {
 }
 
 var providerSet = wire.NewSet(
-	newRestful, wire.Struct(new(wirex.Injector), "*"), initApplication, httpx.NewServer, biz3.NewOrderBiz, biz.NewRestaurantHTTPClient, biz2.NewUserHTTPClient, order.NewMongodb, mongodbx.NewClient,
+	newRestful, wire.Struct(new(wirex.Injector), "*"), initApplication, httpx.NewServer, biz3.NewOrderBiz, biz.NewRestaurantHTTPClient, biz.NewMenuHTTPClient, biz2.NewUserHTTPClient, order.NewMongodb, mongodbx.NewClient,
 )

--- a/app/domain/order/biz/order.go
+++ b/app/domain/order/biz/order.go
@@ -18,6 +18,7 @@ import (
 
 type orderBiz struct {
 	restaurantService restB.IRestaurantBiz
+	menuService       restB.IMenuBiz
 	userService       userB.IUserBiz
 
 	orders repo.IOrderRepo
@@ -26,6 +27,7 @@ type orderBiz struct {
 // NewOrderBiz create and return a new order orderB
 func NewOrderBiz(
 	restaurantService restB.IRestaurantBiz,
+	menuService restB.IMenuBiz,
 	userService userB.IUserBiz,
 	orders repo.IOrderRepo,
 ) orderB.IOrderBiz {
@@ -78,6 +80,15 @@ func (i *orderBiz) CreateOrder(
 			zap.String("user_id", userID.String()),
 		)
 		return nil, errorx.Wrap(http.StatusNotFound, 404, errors.New("user not found"))
+	}
+
+	newItems := make([]model.OrderItem, 0, len(items))
+	for _, item := range items {
+		newItems = append(newItems, model.OrderItem{
+			MenuItemID: "",
+			Quantity:   0,
+			Price:      item.Price,
+		})
 	}
 
 	order = model.NewOrder(user.ID, restaurant.ID, items, address, totalAmount)

--- a/app/domain/order/biz/order.go
+++ b/app/domain/order/biz/order.go
@@ -82,15 +82,6 @@ func (i *orderBiz) CreateOrder(
 		return nil, errorx.Wrap(http.StatusNotFound, 404, errors.New("user not found"))
 	}
 
-	newItems := make([]model.OrderItem, 0, len(items))
-	for _, item := range items {
-		newItems = append(newItems, model.OrderItem{
-			MenuItemID: "",
-			Quantity:   0,
-			Price:      item.Price,
-		})
-	}
-
 	order = model.NewOrder(user.ID, restaurant.ID, items, address, totalAmount)
 	err = i.orders.Create(ctx, order)
 	if err != nil {

--- a/app/domain/order/biz/order.go
+++ b/app/domain/order/biz/order.go
@@ -33,6 +33,7 @@ func NewOrderBiz(
 ) orderB.IOrderBiz {
 	return &orderBiz{
 		restaurantService: restaurantService,
+		menuService:       menuService,
 		userService:       userService,
 		orders:            orders,
 	}

--- a/app/domain/restaurant/biz/BUILD.bazel
+++ b/app/domain/restaurant/biz/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "biz",
     srcs = [
         "menu.go",
+        "menu_http_client.go",
         "restaurant.go",
         "restaurant_http_client.go",
     ],

--- a/app/domain/restaurant/biz/menu_http_client.go
+++ b/app/domain/restaurant/biz/menu_http_client.go
@@ -1,0 +1,70 @@
+package biz
+
+import (
+	"net/http"
+
+	"github.com/blackhorseya/godine/app/infra/configx"
+	"github.com/blackhorseya/godine/entity/restaurant/biz"
+	"github.com/blackhorseya/godine/entity/restaurant/model"
+	"github.com/blackhorseya/godine/pkg/contextx"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+type menuHTTPClient struct {
+	url    string
+	client *http.Client
+}
+
+// NewMenuHTTPClient is used to create a new menu biz client.
+func NewMenuHTTPClient() biz.IMenuBiz {
+	return &menuHTTPClient{
+		url:    configx.C.RestaurantRestful.HTTP.URL,
+		client: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+	}
+}
+
+func (i *menuHTTPClient) AddMenuItem(
+	ctx contextx.Contextx,
+	restaurantID uuid.UUID,
+	name, description string,
+	price float64,
+) (item *model.MenuItem, err error) {
+	// todo: 2024/6/23|sean|implement me
+	panic("implement me")
+}
+
+func (i *menuHTTPClient) ListMenuItems(
+	ctx contextx.Contextx,
+	restaurantID uuid.UUID,
+) (items []model.MenuItem, total int, err error) {
+	// todo: 2024/6/23|sean|implement me
+	panic("implement me")
+}
+
+func (i *menuHTTPClient) GetMenuItem(
+	ctx contextx.Contextx,
+	restaurantID, menuItemID uuid.UUID,
+) (item *model.MenuItem, err error) {
+	// todo: 2024/6/23|sean|implement me
+	panic("implement me")
+}
+
+func (i *menuHTTPClient) UpdateMenuItem(
+	ctx contextx.Contextx,
+	restaurantID, menuItemID uuid.UUID,
+	name, description string,
+	price float64,
+	isAvailable bool,
+) error {
+	// todo: 2024/6/23|sean|implement me
+	panic("implement me")
+}
+
+func (i *menuHTTPClient) RemoveMenuItem(
+	ctx contextx.Contextx,
+	restaurantID, menuItemID uuid.UUID,
+) error {
+	// todo: 2024/6/23|sean|implement me
+	panic("implement me")
+}


### PR DESCRIPTION
- Add `biz2.NewMenuHTTPClient` to `providerSet` in `adapter/order/restful/wire.go`
- Update `iMenuBiz` creation in `wire_gen.go`
- Add `menuService` field to `orderBiz` struct in `app/domain/order/biz/order.go`
- Update `NewOrderBiz` function parameters in `app/domain/order/biz/order.go`
- Add logic to populate `newItems` slice in `CreateOrder` function in `app/domain/order/biz/order.go`
- Add `menu_http_client.go` to `srcs` in `app/domain/restaurant/biz/BUILD.bazel`