### PR TITLE
refactor: refactor order listing functions and structs

### DIFF
--- a/entity/order/repo/mock_order.go
+++ b/entity/order/repo/mock_order.go
@@ -69,34 +69,18 @@ func (mr *MockIOrderRepoMockRecorder) GetByID(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockIOrderRepo)(nil).GetByID), ctx, id)
 }
 
-// ListByRestaurantID mocks base method.
-func (m *MockIOrderRepo) ListByRestaurantID(ctx contextx.Contextx, restaurantID string, condition ListCondition) ([]*model.Order, int, error) {
+// List mocks base method.
+func (m *MockIOrderRepo) List(ctx contextx.Contextx, condition ListCondition) ([]*model.Order, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByRestaurantID", ctx, restaurantID, condition)
+	ret := m.ctrl.Call(m, "List", ctx, condition)
 	ret0, _ := ret[0].([]*model.Order)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// ListByRestaurantID indicates an expected call of ListByRestaurantID.
-func (mr *MockIOrderRepoMockRecorder) ListByRestaurantID(ctx, restaurantID, condition any) *gomock.Call {
+// List indicates an expected call of List.
+func (mr *MockIOrderRepoMockRecorder) List(ctx, condition any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByRestaurantID", reflect.TypeOf((*MockIOrderRepo)(nil).ListByRestaurantID), ctx, restaurantID, condition)
-}
-
-// ListByUserID mocks base method.
-func (m *MockIOrderRepo) ListByUserID(ctx contextx.Contextx, userID string, condition ListCondition) ([]*model.Order, int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByUserID", ctx, userID, condition)
-	ret0, _ := ret[0].([]*model.Order)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListByUserID indicates an expected call of ListByUserID.
-func (mr *MockIOrderRepoMockRecorder) ListByUserID(ctx, userID, condition any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByUserID", reflect.TypeOf((*MockIOrderRepo)(nil).ListByUserID), ctx, userID, condition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockIOrderRepo)(nil).List), ctx, condition)
 }

--- a/entity/order/repo/order.go
+++ b/entity/order/repo/order.go
@@ -9,7 +9,9 @@ import (
 
 // ListCondition is a struct that defines the conditions for listing orders
 type ListCondition struct {
-	Status string
+	UserID       string
+	RestaurantID string
+	Status       string
 
 	Limit  int
 	Offset int
@@ -21,15 +23,5 @@ type IOrderRepo interface {
 
 	GetByID(ctx contextx.Contextx, id string) (item *model.Order, err error)
 
-	ListByUserID(
-		ctx contextx.Contextx,
-		userID string,
-		condition ListCondition,
-	) (items []*model.Order, total int, err error)
-
-	ListByRestaurantID(
-		ctx contextx.Contextx,
-		restaurantID string,
-		condition ListCondition,
-	) (items []*model.Order, total int, err error)
+	List(ctx contextx.Contextx, condition ListCondition) (items []*model.Order, total int, err error)
 }


### PR DESCRIPTION
- Remove the `ListByUserID` and `ListByRestaurantID` functions from `mongodb.go`
- Change the argument of the `List` function in `mongodb.go` to only accept `condition ListCondition`
- Update the `ListByRestaurantID` function in `mock_order.go` to `List` and remove `restaurantID` parameter
- Update the `ListByUserID` function in `mock_order.go` to `List` and remove `userID` parameter
- Modify the `ListCondition` struct in `order.go` to include `UserID` and `RestaurantID` fields