### PR TITLE
chore: consolidate dependencies for logistics biz integration

### DIFF
--- a/adapter/logistics/restful/BUILD.bazel
+++ b/adapter/logistics/restful/BUILD.bazel
@@ -11,8 +11,11 @@ go_library(
     deps = [
         "//adapter/logistics/wirex",
         "//api/logistics/restful",
+        "//app/domain/logistics/biz",
+        "//app/domain/logistics/repo/delivery",
         "//app/infra/configx",
         "//app/infra/otelx",
+        "//app/infra/storage/mongodbx",
         "//app/infra/transports/httpx",
         "//pkg/adapterx",
         "//pkg/contextx",

--- a/adapter/logistics/restful/wire.go
+++ b/adapter/logistics/restful/wire.go
@@ -6,8 +6,10 @@ package restful
 
 import (
 	"github.com/blackhorseya/godine/adapter/logistics/wirex"
+	"github.com/blackhorseya/godine/app/domain/logistics/biz"
 	"github.com/blackhorseya/godine/app/infra/configx"
 	"github.com/blackhorseya/godine/app/infra/otelx"
+	"github.com/blackhorseya/godine/app/infra/storage/mongodbx"
 	"github.com/blackhorseya/godine/app/infra/transports/httpx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
 	"github.com/blackhorseya/godine/pkg/contextx"
@@ -41,6 +43,9 @@ var providerSet = wire.NewSet(
 	wire.Struct(new(wirex.Injector), "*"),
 	initApplication,
 	httpx.NewServer,
+
+	biz.ProviderLogisticsSet,
+	mongodbx.NewClient,
 )
 
 func New(v *viper.Viper) (adapterx.Restful, error) {

--- a/adapter/logistics/wirex/BUILD.bazel
+++ b/adapter/logistics/wirex/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["injector.go"],
     importpath = "github.com/blackhorseya/godine/adapter/logistics/wirex",
     visibility = ["//visibility:public"],
-    deps = ["//app/infra/configx"],
+    deps = [
+        "//app/infra/configx",
+        "//entity/logistics/biz",
+    ],
 )

--- a/adapter/logistics/wirex/injector.go
+++ b/adapter/logistics/wirex/injector.go
@@ -2,9 +2,12 @@ package wirex
 
 import (
 	"github.com/blackhorseya/godine/app/infra/configx"
+	"github.com/blackhorseya/godine/entity/logistics/biz"
 )
 
 // Injector is a struct that contains all the dependencies needed by the order package.
 type Injector struct {
 	A *configx.Application
+
+	LogisticsService biz.ILogisticsBiz
 }


### PR DESCRIPTION
- Add dependencies for logistics biz in `adapter/logistics/wirex/BUILD.bazel`
- Include `biz` package in dependencies for `adapter/logistics/restful/wire.go`
- Add `biz` and `delivery` dependencies in `adapter/logistics/restful/wire_gen.go`