### PR TITLE
feat: integrate OTel collector, Jaeger, and Prometheus services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -76,8 +76,24 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: changeme
     volumes:
       - mongo-data:/data/db
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./configs/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
     ports:
-      - "27017:27017"
+      - 26686:16686
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - 29090:9090
 
 volumes:
   mongo-data:

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -15,7 +15,7 @@ restaurantRestful:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
   otel:
-    target: jaeger:4317
+    target: otel-collector:4317
 
 orderRestful:
   name: godine-order-restful
@@ -34,7 +34,7 @@ orderRestful:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
   otel:
-    target: jaeger:4317
+    target: otel-collector:4317
 
 userRestful:
   name: godine-user-restful
@@ -53,7 +53,7 @@ userRestful:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
   otel:
-    target: jaeger:4317
+    target: otel-collector:4317
 
 logisticsRestful:
   name: godine-logistics-restful
@@ -72,4 +72,4 @@ logisticsRestful:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
   otel:
-    target: jaeger:4317
+    target: otel-collector:4317

--- a/configs/otel-collector-config.yaml
+++ b/configs/otel-collector-config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+
+extensions:
+  health_check: {}
+
+exporters:
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  prometheus:
+    endpoint: "0.0.0.0:9090"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:9090']


### PR DESCRIPTION
- Add `otel-collector`, `jaeger`, and `prometheus` services to `compose.yaml`
- Update `configs/example.yaml` to use `otel-collector` instead of `jaeger`
- Add `configs/otel-collector-config.yaml` with OTel collector configuration
- Add `configs/prometheus.yml` with Prometheus configuration