### PR TITLE
chore: refactor notification domain logic

### DIFF
--- a/app/domain/notification/biz/BUILD.bazel
+++ b/app/domain/notification/biz/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
     importpath = "github.com/blackhorseya/godine/app/domain/notification/biz",
     visibility = ["//visibility:public"],
     deps = [
+        "//app/infra/otelx",
         "//entity/notification/biz",
         "//entity/notification/model",
+        "//entity/notification/repo",
         "//pkg/contextx",
         "@com_github_google_wire//:wire",
     ],

--- a/app/domain/notification/biz/notification.go
+++ b/app/domain/notification/biz/notification.go
@@ -1,35 +1,47 @@
 package biz
 
 import (
+	"github.com/blackhorseya/godine/app/infra/otelx"
 	"github.com/blackhorseya/godine/entity/notification/biz"
 	"github.com/blackhorseya/godine/entity/notification/model"
+	"github.com/blackhorseya/godine/entity/notification/repo"
 	"github.com/blackhorseya/godine/pkg/contextx"
 )
 
 type notification struct {
+	notifications repo.INotificationRepo
 }
 
 // NewNotification creates a new notification service.
 func NewNotification() biz.INotificationBiz {
-	return &notification{}
+	return &notification{
+		// todo: 2024/6/26|sean|you should inject the notification repository here
+		notifications: nil,
+	}
 }
 
 func (i *notification) CreateNotification(ctx contextx.Contextx, notification *model.Notification) error {
-	// todo: 2024/6/26|sean|implement me
-	panic("implement me")
+	ctx, span := otelx.Span(ctx, "biz.notification.CreateNotification")
+	defer span.End()
+
+	return i.notifications.Create(ctx, notification)
 }
 
 func (i *notification) UpdateNotificationStatus(ctx contextx.Contextx, notificationID string, status string) error {
-	// todo: 2024/6/26|sean|implement me
-	panic("implement me")
+	ctx, span := otelx.Span(ctx, "biz.notification.UpdateNotificationStatus")
+	defer span.End()
+
+	return i.notifications.UpdateStatus(ctx, notificationID, status)
 }
 
 func (i *notification) GetNotification(
 	ctx contextx.Contextx,
 	notificationID string,
 ) (item *model.Notification, err error) {
-	// todo: 2024/6/26|sean|implement me
-	panic("implement me")
+	ctx, span := otelx.Span(ctx, "biz.notification.GetNotification")
+	defer span.End()
+
+	return i.notifications.GetByID(ctx, notificationID)
 }
 
 func (i *notification) ListNotificationsByUser(
@@ -37,6 +49,12 @@ func (i *notification) ListNotificationsByUser(
 	userID string,
 	options biz.ListNotificationsOptions,
 ) (items []*model.Notification, total int, err error) {
-	// todo: 2024/6/26|sean|implement me
-	panic("implement me")
+	ctx, span := otelx.Span(ctx, "biz.notification.ListNotificationsByUser")
+	defer span.End()
+
+	return i.notifications.List(ctx, repo.ListCondition{
+		Limit:  options.Size,
+		Offset: (options.Page - 1) * options.Size,
+		UserID: userID,
+	})
 }


### PR DESCRIPTION
- Add `app/infra/otelx` as a dependency in `app/domain/notification/biz/BUILD.bazel`
- Inject `notifications` repository in `NewNotification` function in `app/domain/notification/biz/notification.go`
- Implement `ctx` and `span` in various functions in `app/domain/notification/biz/notification.go`
- Update `ListNotificationsByUser` function parameters and return values in `app/domain/notification/biz/notification.go`