### PR TITLE
build: integrate Redis storage for restaurant repository

### DIFF
--- a/adapter/restaurant/restful/BUILD.bazel
+++ b/adapter/restaurant/restful/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//app/infra/configx",
         "//app/infra/otelx",
         "//app/infra/storage/mongodbx",
+        "//app/infra/storage/redix",
         "//app/infra/transports/httpx",
         "//pkg/adapterx",
         "//pkg/contextx",

--- a/adapter/restaurant/restful/wire.go
+++ b/adapter/restaurant/restful/wire.go
@@ -11,6 +11,7 @@ import (
 	"github.com/blackhorseya/godine/app/infra/configx"
 	"github.com/blackhorseya/godine/app/infra/otelx"
 	"github.com/blackhorseya/godine/app/infra/storage/mongodbx"
+	"github.com/blackhorseya/godine/app/infra/storage/redix"
 	"github.com/blackhorseya/godine/app/infra/transports/httpx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
 	"github.com/blackhorseya/godine/pkg/contextx"
@@ -49,6 +50,7 @@ var providerSet = wire.NewSet(
 	biz.NewMenuBiz,
 	restaurant.NewMongodb,
 	mongodbx.NewClient,
+	redix.NewRedis,
 )
 
 func New(v *viper.Viper) (adapterx.Restful, error) {

--- a/app/domain/restaurant/repo/restaurant/BUILD.bazel
+++ b/app/domain/restaurant/repo/restaurant/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//entity/domain/restaurant/repo",
         "//pkg/contextx",
         "//pkg/errorx",
+        "@com_github_redis_go_redis_v9//:go-redis",
         "@org_mongodb_go_mongo_driver//bson",
         "@org_mongodb_go_mongo_driver//mongo",
         "@org_mongodb_go_mongo_driver//mongo/options",

--- a/app/domain/restaurant/repo/restaurant/mongodb.go
+++ b/app/domain/restaurant/repo/restaurant/mongodb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blackhorseya/godine/entity/domain/restaurant/repo"
 	"github.com/blackhorseya/godine/pkg/contextx"
 	"github.com/blackhorseya/godine/pkg/errorx"
+	"github.com/redis/go-redis/v9"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -23,12 +24,16 @@ const (
 )
 
 type mongodb struct {
-	rw *mongo.Client
+	rw  *mongo.Client
+	rdb *redis.Client
 }
 
 // NewMongodb is a function that returns a new mongodb instance that implements the IRestaurantRepo interface
-func NewMongodb(rw *mongo.Client) repo.IRestaurantRepo {
-	return &mongodb{rw: rw}
+func NewMongodb(rw *mongo.Client, rdb *redis.Client) repo.IRestaurantRepo {
+	return &mongodb{
+		rw:  rw,
+		rdb: rdb,
+	}
 }
 
 func (i *mongodb) Create(ctx contextx.Contextx, data *model.Restaurant) (err error) {


### PR DESCRIPTION
- Add `//app/infra/storage/redix` to the `BUILD.bazel` file in `adapter/restaurant/restful`
- Add `github.com/blackhorseya/godine/app/infra/storage/redix` to imports in the `wire.go` file in `adapter/restaurant/restful`
- Add `github.com/blackhorseya/godine/app/infra/storage/redix` to imports in the `wire_gen.go` file in `adapter/restaurant/restful`
- Add `@com_github_redis_go_redis_v9//:go-redis` to the `BUILD.bazel` file in `app/domain/restaurant/repo/restaurant`
- Add `github.com/redis/go-redis/v9` to imports in the `mongodb.go` file in `app/domain/restaurant/repo/restaurant`
- Add `github.com/blackhorseya/godine/app/infra/storage/redix` to imports in the `mongodb_external_test.go` file in `app/domain/restaurant/repo/restaurant`