### PR TITLE
feat: integrate Redis service and configurations across services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -92,6 +92,10 @@ services:
     volumes:
       - mongo-data:/data/db
 
+  redis:
+    image: redis:7
+    restart: always
+
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
     command: [ "--config=/etc/otel-collector-config.yaml" ]

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -14,6 +14,9 @@ restaurantRestful:
     mongodb:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
+    redis:
+      addr: redis:6379
+
   otel:
     target: otel-collector:4317
 
@@ -32,6 +35,9 @@ orderRestful:
   storage:
     mongodb:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
+
+    redis:
+      addr: redis:6379
 
   otel:
     target: otel-collector:4317
@@ -52,6 +58,9 @@ userRestful:
     mongodb:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
 
+    redis:
+      addr: redis:6379
+
   otel:
     target: otel-collector:4317
 
@@ -70,6 +79,9 @@ logisticsRestful:
   storage:
     mongodb:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
+
+    redis:
+      addr: redis:6379
 
   kafka:
     brokers:
@@ -95,6 +107,9 @@ notifyRestful:
   storage:
     mongodb:
       dsn: mongodb://admin:changeme@mongodb/?retryWrites=true&w=majority
+
+    redis:
+      addr: redis:6379
 
   otel:
     target: otel-collector:4317


### PR DESCRIPTION
- Add `redis` service to `compose.yaml`
- Add `redis` configuration to `configs/example.yaml` for `restaurantRestful`, `orderRestful`, `userRestful`, `logisticsRestful`, and `notifyRestful` services