### PR TITLE
chore: update storage dependency to mariadbx across the codebase

### DIFF
--- a/adapter/order/restful/BUILD.bazel
+++ b/adapter/order/restful/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         "//app/domain/user/biz",
         "//app/infra/configx",
         "//app/infra/otelx",
-        "//app/infra/storage/mongodbx",
+        "//app/infra/storage/mariadbx",
         "//app/infra/transports/httpx",
         "//pkg/adapterx",
         "//pkg/contextx",

--- a/adapter/order/restful/wire.go
+++ b/adapter/order/restful/wire.go
@@ -14,7 +14,7 @@ import (
 	biz3 "github.com/blackhorseya/godine/app/domain/user/biz"
 	"github.com/blackhorseya/godine/app/infra/configx"
 	"github.com/blackhorseya/godine/app/infra/otelx"
-	"github.com/blackhorseya/godine/app/infra/storage/mongodbx"
+	"github.com/blackhorseya/godine/app/infra/storage/mariadbx"
 	"github.com/blackhorseya/godine/app/infra/transports/httpx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
 	"github.com/blackhorseya/godine/pkg/contextx"
@@ -53,8 +53,8 @@ var providerSet = wire.NewSet(
 	biz2.NewRestaurantHTTPClient,
 	biz2.NewMenuHTTPClient,
 	biz3.NewUserHTTPClient,
-	order.NewMongodb,
-	mongodbx.NewClient,
+	order.NewMariadb,
+	mariadbx.NewClient,
 	biz4.NewLogisticsHTTPClient,
 	biz5.NewNotificationHTTPClient,
 )

--- a/app/domain/order/repo/order/mariadb.go
+++ b/app/domain/order/repo/order/mariadb.go
@@ -134,6 +134,9 @@ func (i *mariadb) List(
 	}
 	query = query.Limit(condition.Limit).Offset(condition.Offset)
 
+	// Order by updated_at descending
+	query = query.Order("updated_at DESC")
+
 	// Execute the query
 	err = query.Find(&orders).Error
 	if err != nil {

--- a/app/domain/order/repo/order/mariadb_external_test.go
+++ b/app/domain/order/repo/order/mariadb_external_test.go
@@ -34,7 +34,7 @@ func (s *mariadbExternalTester) SetupTest() {
 	err = logging.Init(app.Log)
 	s.Require().NoError(err)
 
-	rw, err := mariadbx.NewClientV2(app)
+	rw, err := mariadbx.NewClient(app)
 	s.Require().NoError(err)
 	s.rw = rw
 

--- a/app/infra/storage/mariadbx/BUILD.bazel
+++ b/app/infra/storage/mariadbx/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//app/infra/configx",
         "@com_github_go_sql_driver_mysql//:mysql",
-        "@com_github_jmoiron_sqlx//:sqlx",
         "@io_gorm_driver_mysql//:mysql",
         "@io_gorm_gorm//:gorm",
     ],

--- a/app/infra/storage/mariadbx/client.go
+++ b/app/infra/storage/mariadbx/client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/blackhorseya/godine/app/infra/configx"
 	_ "github.com/go-sql-driver/mysql" // import MySQL driver
-	"github.com/jmoiron/sqlx"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
@@ -17,21 +16,7 @@ const (
 )
 
 // NewClient init mysql client.
-func NewClient(app *configx.Application) (*sqlx.DB, error) {
-	db, err := sqlx.Open("mysql", app.Storage.Mysql.DSN)
-	if err != nil {
-		return nil, fmt.Errorf("open mysql client error: %w", err)
-	}
-
-	db.SetConnMaxLifetime(defaultMaxLifetime)
-	db.SetMaxOpenConns(defaultConns)
-	db.SetMaxIdleConns(defaultConns)
-
-	return db, nil
-}
-
-// NewClientV2 init mysql client.
-func NewClientV2(app *configx.Application) (*gorm.DB, error) {
+func NewClient(app *configx.Application) (*gorm.DB, error) {
 	db, err := gorm.Open(mysql.Open(app.Storage.Mysql.DSN), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("open mysql client error: %w", err)


### PR DESCRIPTION
- Update the storage dependency in `BUILD.bazel` from mongodbx to mariadbx
- Update the storage dependency in `wire.go` from mongodbx to mariadbx
- Update the storage dependency in `wire_gen.go` from mongodbx to mariadbx
- Update the storage dependency in `mariadb_external_test.go` from mariadbxV2 to mariadbx
- Remove the dependency on `jmoiron/sqlx` in `BUILD.bazel` and `client.go`