### PR TITLE
feat: update gRPC server initialization and configuration steps

### DIFF
--- a/adapter/platform/grpc/BUILD.bazel
+++ b/adapter/platform/grpc/BUILD.bazel
@@ -9,9 +9,14 @@ go_library(
     importpath = "github.com/blackhorseya/godine/adapter/platform/grpc",
     visibility = ["//visibility:public"],
     deps = [
+        "//app/infra/configx",
+        "//app/infra/otelx",
+        "//app/infra/transports/grpcx",
         "//pkg/adapterx",
         "//pkg/contextx",
         "@com_github_gin_gonic_gin//:gin",
         "@com_github_spf13_viper//:viper",
+        "@org_golang_google_grpc//:grpc",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/adapter/platform/grpc/impl.go
+++ b/adapter/platform/grpc/impl.go
@@ -1,21 +1,32 @@
 package grpc
 
 import (
+	"github.com/blackhorseya/godine/app/infra/transports/grpcx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
 	"github.com/blackhorseya/godine/pkg/contextx"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 type impl struct {
+	server *grpcx.Server
 }
 
 // NewServer creates and returns a new server.
-func NewServer() adapterx.Restful {
-	return &impl{}
+func NewServer(server *grpcx.Server) adapterx.Restful {
+	return &impl{
+		server: server,
+	}
 }
 
 func (i *impl) Start() error {
-	// TODO: 2024/8/21|sean|implement grpc server start
+	ctx := contextx.Background()
+	err := i.server.Start(ctx)
+	if err != nil {
+		ctx.Error("Failed to start grpc server", zap.Error(err))
+		return err
+	}
+
 	return nil
 }
 
@@ -23,7 +34,10 @@ func (i *impl) AwaitSignal() error {
 	ctx := contextx.Background()
 	ctx.Info("receive signal to stop server")
 
-	// TODO: 2024/8/21|sean|implement grpc server stop
+	if err := i.server.Stop(ctx); err != nil {
+		ctx.Error("Failed to stop server", zap.Error(err))
+		return err
+	}
 
 	return nil
 }

--- a/adapter/platform/grpc/wire.go
+++ b/adapter/platform/grpc/wire.go
@@ -5,11 +5,47 @@
 package grpc
 
 import (
+	"fmt"
+
+	"github.com/blackhorseya/godine/app/infra/configx"
+	"github.com/blackhorseya/godine/app/infra/otelx"
+	"github.com/blackhorseya/godine/app/infra/transports/grpcx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
+	"github.com/blackhorseya/godine/pkg/contextx"
 	"github.com/google/wire"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
+const serverName = "platform"
+
+// NewInitServersFn creates and returns a new InitServers function.
+func NewInitServersFn() grpcx.InitServers {
+	return func(s *grpc.Server) {
+		// TODO: 2024/8/21|sean|init servers
+	}
+}
+
+func initApplication(config *configx.Configuration) (*configx.Application, error) {
+	app, err := config.GetService(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s: %w", serverName, err)
+	}
+
+	err = otelx.SetupOTelSDK(contextx.Background(), app)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup otel sdk: %w", err)
+	}
+
+	return app, nil
+}
+
 func New(v *viper.Viper) (adapterx.Restful, error) {
-	panic(wire.Build(NewServer))
+	panic(wire.Build(
+		NewServer,
+		grpcx.NewServer,
+		initApplication,
+		configx.NewConfiguration,
+		NewInitServersFn,
+	))
 }

--- a/adapter/platform/grpc/wire_gen.go
+++ b/adapter/platform/grpc/wire_gen.go
@@ -7,13 +7,57 @@
 package grpc
 
 import (
+	"fmt"
+	"github.com/blackhorseya/godine/app/infra/configx"
+	"github.com/blackhorseya/godine/app/infra/otelx"
+	"github.com/blackhorseya/godine/app/infra/transports/grpcx"
 	"github.com/blackhorseya/godine/pkg/adapterx"
+	"github.com/blackhorseya/godine/pkg/contextx"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 // Injectors from wire.go:
 
 func New(v *viper.Viper) (adapterx.Restful, error) {
-	restful := NewServer()
+	configuration, err := configx.NewConfiguration(v)
+	if err != nil {
+		return nil, err
+	}
+	application, err := initApplication(configuration)
+	if err != nil {
+		return nil, err
+	}
+	initServers := NewInitServersFn()
+	server, err := grpcx.NewServer(application, initServers)
+	if err != nil {
+		return nil, err
+	}
+	restful := NewServer(server)
 	return restful, nil
+}
+
+// wire.go:
+
+const serverName = "platform"
+
+// NewInitServersFn creates and returns a new InitServers function.
+func NewInitServersFn() grpcx.InitServers {
+	return func(s *grpc.Server) {
+
+	}
+}
+
+func initApplication(config *configx.Configuration) (*configx.Application, error) {
+	app, err := config.GetService(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s: %w", serverName, err)
+	}
+
+	err = otelx.SetupOTelSDK(contextx.Background(), app)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup otel sdk: %w", err)
+	}
+
+	return app, nil
 }


### PR DESCRIPTION
- Add dependencies `app/infra/configx`, `app/infra/otelx`, and `app/infra/transports/grpcx` to the `go_library` in `adapter/platform/grpc/BUILD.bazel`
- Add `server *grpcx.Server` field to the `impl` struct in `adapter/platform/grpc/impl.go`
- Modify `NewServer` function in `adapter/platform/grpc/impl.go` to accept `server *grpcx.Server` parameter
- Add constants `serverName` and `NewInitServersFn` function to `adapter/platform/grpc/wire.go`
- Add function `initApplication` to `adapter/platform/grpc/wire.go`
- Modify the `New` function in `adapter/platform/grpc/wire.go` to include additional configuration steps
- Add function `initApplication` to `adapter/platform/grpc/wire_gen.go`
- Modify the `New` function in `adapter/platform/grpc/wire_gen.go` to include additional configuration steps