### PR TITLE
feat: refactor authentication middleware and methods

### DIFF
--- a/adapter/platform/grpc/wire.go
+++ b/adapter/platform/grpc/wire.go
@@ -62,10 +62,6 @@ func initApplication(config *configx.Configuration) (*configx.Application, error
 	return app, nil
 }
 
-func initAuthx(app *configx.Application) (*authx.Authx, error) {
-	return authx.New(app.Auth0)
-}
-
 func New(v *viper.Viper) (adapterx.Restful, error) {
 	panic(wire.Build(
 		NewServer,
@@ -75,7 +71,7 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 		initApplication,
 		configx.NewConfiguration,
 		NewInitServersFn,
-		initAuthx,
+		authx.New,
 
 		biz.NewAccountService,
 		biz2.NewRestaurantService,

--- a/adapter/platform/grpc/wire_gen.go
+++ b/adapter/platform/grpc/wire_gen.go
@@ -38,14 +38,14 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	if err != nil {
 		return nil, err
 	}
-	authx, err := initAuthx(application)
+	authxAuthx, err := authx.New(application)
 	if err != nil {
 		return nil, err
 	}
 	injector := &wirex.Injector{
 		C:     configuration,
 		A:     application,
-		Authx: authx,
+		Authx: authxAuthx,
 	}
 	accountServiceServer := biz.NewAccountService()
 	restaurantServiceServer := biz2.NewRestaurantService()
@@ -96,8 +96,4 @@ func initApplication(config *configx.Configuration) (*configx.Application, error
 	}
 
 	return app, nil
-}
-
-func initAuthx(app *configx.Application) (*authx.Authx, error) {
-	return authx.New(app.Auth0)
 }

--- a/adapter/user/restful/wire.go
+++ b/adapter/user/restful/wire.go
@@ -40,10 +40,6 @@ func initApplication(v *viper.Viper) (*configx.Application, error) {
 	return app, nil
 }
 
-func initAuthx(app *configx.Application) (*authx.Authx, error) {
-	return authx.New(app.Auth0)
-}
-
 var providerSet = wire.NewSet(
 	newRestful,
 
@@ -51,7 +47,7 @@ var providerSet = wire.NewSet(
 	configx.NewConfiguration,
 	initApplication,
 	httpx.NewServer,
-	initAuthx,
+	authx.New,
 	authz.New,
 
 	biz.NewUserBiz,

--- a/adapter/user/restful/wire_gen.go
+++ b/adapter/user/restful/wire_gen.go
@@ -38,7 +38,7 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	if err != nil {
 		return nil, err
 	}
-	authx, err := initAuthx(application)
+	authxAuthx, err := authx.New(application)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	injector := &wirex.Injector{
 		C:           configuration,
 		A:           application,
-		Authx:       authx,
+		Authx:       authxAuthx,
 		Authz:       authzAuthz,
 		UserService: iUserBiz,
 	}
@@ -88,10 +88,6 @@ func initApplication(v *viper.Viper) (*configx.Application, error) {
 	return app, nil
 }
 
-func initAuthx(app *configx.Application) (*authx.Authx, error) {
-	return authx.New(app.Auth0)
-}
-
 var providerSet = wire.NewSet(
-	newRestful, wire.Struct(new(wirex.Injector), "*"), configx.NewConfiguration, initApplication, httpx.NewServer, initAuthx, authz.New, biz.NewUserBiz, user.NewMongodb, mongodbx.NewClient,
+	newRestful, wire.Struct(new(wirex.Injector), "*"), configx.NewConfiguration, initApplication, httpx.NewServer, authx.New, authz.New, biz.NewUserBiz, user.NewMongodb, mongodbx.NewClient,
 )

--- a/app/infra/authx/BUILD.bazel
+++ b/app/infra/authx/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/blackhorseya/godine/app/infra/authx",
     visibility = ["//visibility:public"],
     deps = [
+        "//app/infra/configx",
         "//app/infra/otelx",
         "//entity/domain/user/model",
         "//pkg/contextx",

--- a/app/infra/authx/BUILD.bazel
+++ b/app/infra/authx/BUILD.bazel
@@ -2,10 +2,14 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "authx",
-    srcs = ["authx.go"],
+    srcs = [
+        "authx.go",
+        "grpc_server_middleware.go",
+    ],
     importpath = "github.com/blackhorseya/godine/app/infra/authx",
     visibility = ["//visibility:public"],
     deps = [
+        "//app/infra/otelx",
         "//entity/domain/user/model",
         "//pkg/contextx",
         "//pkg/errorx",
@@ -15,6 +19,11 @@ go_library(
         "@com_github_auth0_go_jwt_middleware_v2//validator",
         "@com_github_coreos_go_oidc_v3//oidc",
         "@com_github_gin_gonic_gin//:gin",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//:go-grpc-middleware",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
         "@org_golang_x_oauth2//:oauth2",
         "@org_uber_go_zap//:zap",
     ],

--- a/app/infra/authx/authx.go
+++ b/app/infra/authx/authx.go
@@ -87,7 +87,7 @@ func New(options Options) (*Authx, error) {
 				contextx.Background().Error("error validating token", zap.Error(err))
 			}),
 		),
-		SkipPaths: []string{},
+		SkipPaths: []string{"/grpc.health.v1.Health", "/grpc.reflection.v1alpha.ServerReflection"},
 	}, nil
 }
 

--- a/app/infra/authx/grpc_server_middleware.go
+++ b/app/infra/authx/grpc_server_middleware.go
@@ -1,0 +1,101 @@
+package authx
+
+import (
+	"context"
+
+	"github.com/blackhorseya/godine/app/infra/otelx"
+	"github.com/blackhorseya/godine/entity/domain/user/model"
+	"github.com/blackhorseya/godine/pkg/contextx"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const keyAccessToken = "access_token"
+
+// UnaryServerInterceptor is used to create a new unary interceptor
+func (x *Authx) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(c context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		ctx, err := contextx.FromContext(c)
+		if err != nil {
+			return nil, status.Newf(codes.Internal, "failed to get contextx: %v", err).Err()
+		}
+
+		ctx, span := otelx.Span(ctx, "authx.grpc.UnaryServerInterceptor")
+		defer span.End()
+
+		if x.SkipPath(info.FullMethod) {
+			ctx.Debug(
+				"skip authx middleware",
+				zap.Strings("skip_paths", x.SkipPaths),
+				zap.String("full_method", info.FullMethod),
+			)
+			return handler(c, req)
+		}
+
+		account, err := extractAccount(c, x)
+		if err != nil {
+			return nil, err
+		}
+
+		ctx = contextx.WithValue(ctx, contextx.KeyHandler, account)
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor is used to create a new stream interceptor
+func (x *Authx) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx, err := contextx.FromContext(stream.Context())
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to get contextx: %v", err)
+		}
+
+		ctx, span := otelx.Span(ctx, "authx.grpc.StreamServerInterceptor")
+		defer span.End()
+
+		if x.SkipPath(info.FullMethod) {
+			ctx.Debug(
+				"skip authx middleware",
+				zap.Strings("skip_paths", x.SkipPaths),
+				zap.String("full_method", info.FullMethod),
+			)
+			return handler(srv, stream)
+		}
+
+		account, err := extractAccount(stream.Context(), x)
+		if err != nil {
+			return err
+		}
+		ctx = contextx.WithValue(ctx, contextx.KeyHandler, account)
+
+		wrappedStream := grpc_middleware.WrapServerStream(stream)
+		wrappedStream.WrappedContext = ctx
+
+		return handler(srv, stream)
+	}
+}
+
+func extractAccount(c context.Context, authx *Authx) (*model.Account, error) {
+	headers, ok := metadata.FromIncomingContext(c)
+	if !ok {
+		return nil, status.New(codes.Unauthenticated, "metadata not found").Err()
+	}
+
+	tokens := headers.Get(keyAccessToken)
+	if len(tokens) < 1 {
+		return nil, status.New(codes.Unauthenticated, "access token not found").Err()
+	}
+	accessToken := tokens[0]
+
+	account, err := authx.ExtractAccountFromToken(accessToken)
+	if err != nil {
+		return nil, status.New(codes.Unauthenticated, "invalid access token").Err()
+	}
+
+	return account, nil
+}

--- a/app/infra/configx/BUILD.bazel
+++ b/app/infra/configx/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/blackhorseya/godine/app/infra/configx",
     visibility = ["//visibility:public"],
     deps = [
-        "//app/infra/authx",
         "//pkg/logging",
         "//pkg/netx",
         "@com_github_google_uuid//:uuid",

--- a/app/infra/configx/app.go
+++ b/app/infra/configx/app.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/blackhorseya/godine/app/infra/authx"
 	"github.com/blackhorseya/godine/pkg/logging"
 	"github.com/blackhorseya/godine/pkg/netx"
 	"github.com/google/uuid"
@@ -32,7 +31,13 @@ type Application struct {
 	HTTP HTTP            `json:"http" yaml:"http"`
 	GRPC GRPC            `json:"grpc" yaml:"grpc"`
 
-	Auth0 authx.Options `json:"auth0" yaml:"auth0"`
+	Auth0 struct {
+		Domain       string   `json:"domain" yaml:"domain"`
+		ClientID     string   `json:"client_id" yaml:"clientID"`
+		ClientSecret string   `json:"client_secret" yaml:"clientSecret"`
+		CallbackURL  string   `json:"callback_url" yaml:"callbackURL"`
+		Audiences    []string `json:"audiences" yaml:"audiences"`
+	} `json:"auth0" yaml:"auth0"`
 
 	Casbin struct {
 		// Enabled is the casbin enabled


### PR DESCRIPTION
- Add `grpc_server_middleware.go` to the `srcs` list in `BUILD.bazel`
- Change receiver variable `a` to `x` in `VerifyIDToken` method
- Change receiver variable `a` to `x` in `ParseJWT` method
- Add `ExtractAccountFromToken` method to `authx.go`
- Add `SkipPath` method to `authx.go`
- Add `grpc_server_middleware.go` file with new content