### PR TITLE
refactor: update gRPC client middleware to include authx functionality

### DIFF
--- a/adapter/platform/grpc/wire_gen.go
+++ b/adapter/platform/grpc/wire_gen.go
@@ -92,7 +92,7 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	if err != nil {
 		return nil, err
 	}
-	grpcxClient, err := grpcx.NewClient(configuration)
+	grpcxClient, err := grpcx.NewClient(configuration, authxAuthx)
 	if err != nil {
 		return nil, err
 	}

--- a/app/infra/authx/BUILD.bazel
+++ b/app/infra/authx/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "authx",
     srcs = [
         "authx.go",
+        "grpc_client_middleware.go",
         "grpc_server_middleware.go",
     ],
     importpath = "github.com/blackhorseya/godine/app/infra/authx",

--- a/app/infra/authx/grpc_client_middleware.go
+++ b/app/infra/authx/grpc_client_middleware.go
@@ -1,0 +1,69 @@
+package authx
+
+import (
+	"context"
+
+	userM "github.com/blackhorseya/godine/entity/domain/user/model"
+	"github.com/blackhorseya/godine/pkg/contextx"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// UnaryClientInterceptor is used to create a new grpc unary client interceptor
+func (x *Authx) UnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		c context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx, err := contextx.FromContext(c)
+		if err != nil {
+			return err
+		}
+
+		handler, err := userM.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+		ctx.Debug("unary client interceptor", zap.Any("handler", &handler))
+
+		c = metadata.NewOutgoingContext(c, metadata.New(map[string]string{
+			"access_token": handler.AccessToken,
+		}))
+
+		return invoker(c, method, req, reply, cc, opts...)
+	}
+}
+
+// StreamClientInterceptor is used to create a new grpc stream client interceptor
+func (x *Authx) StreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(
+		c context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx, err := contextx.FromContext(c)
+		if err != nil {
+			return nil, err
+		}
+
+		handler, err := userM.FromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ctx.Debug("unary client interceptor", zap.Any("handler", &handler))
+
+		c = metadata.NewOutgoingContext(c, metadata.New(map[string]string{
+			"access_token": handler.AccessToken,
+		}))
+
+		return streamer(c, desc, cc, method, opts...)
+	}
+}

--- a/app/infra/transports/grpcx/client.go
+++ b/app/infra/transports/grpcx/client.go
@@ -3,6 +3,7 @@ package grpcx
 import (
 	"fmt"
 
+	"github.com/blackhorseya/godine/app/infra/authx"
 	"github.com/blackhorseya/godine/app/infra/configx"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -17,12 +18,16 @@ type Client struct {
 }
 
 // NewClient is used to create a new grpc client
-func NewClient(config *configx.Configuration) (*Client, error) {
+func NewClient(config *configx.Configuration, authx *authx.Authx) (*Client, error) {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient()),
-		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient()),
+		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
+			authx.UnaryClientInterceptor(),
+		)),
+		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(
+			authx.StreamClientInterceptor(),
+		)),
 	}
 
 	return &Client{


### PR DESCRIPTION
- Update `adapter/platform/grpc/wire_gen.go` to include `authx.Authx` in the `NewClient` function call
- Add `grpc_client_middleware.go` to the `authx` build in `app/infra/authx/BUILD.bazel`
- Add `grpc_client_middleware.go` file to the `app/infra/authx` package
- Modify `app/infra/transports/grpcx/client.go` to include `authx.Authx` in the `NewClient` function call