### PR TITLE
refactor: refactor package and import paths for payment module

### DIFF
--- a/adapter/platform/BUILD.bazel
+++ b/adapter/platform/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//app/domain/notification/repo/notification",
         "//app/domain/order/biz",
         "//app/domain/order/repo/order",
-        "//app/domain/payment/biz",
+        "//app/domain/payment",
         "//app/domain/restaurant",
         "//app/domain/user/biz",
         "//app/infra/authx",

--- a/adapter/platform/wire.go
+++ b/adapter/platform/wire.go
@@ -11,7 +11,7 @@ import (
 	opsBI "github.com/blackhorseya/godine/app/domain/logistics/biz"
 	notifyBI "github.com/blackhorseya/godine/app/domain/notification/biz"
 	orderBI "github.com/blackhorseya/godine/app/domain/order/biz"
-	payBI "github.com/blackhorseya/godine/app/domain/payment/biz"
+	"github.com/blackhorseya/godine/app/domain/payment"
 	"github.com/blackhorseya/godine/app/domain/restaurant"
 	userBI "github.com/blackhorseya/godine/app/domain/user/biz"
 	"github.com/blackhorseya/godine/app/infra/authx"
@@ -96,8 +96,8 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 		restaurant.ProviderRestaurantBizSet,
 		restaurant.NewRestaurantServiceClient,
 		restaurant.NewMenuServiceClient,
-		payBI.ProviderPaymentBizSet,
-		payBI.NewPaymentServiceClient,
+		payment.ProviderPaymentBizSet,
+		payment.NewPaymentServiceClient,
 		notifyBI.ProviderNotificationBizSet,
 		notifyBI.NewNotificationServiceClient,
 		orderBI.ProviderOrderBizSet,

--- a/adapter/platform/wire_gen.go
+++ b/adapter/platform/wire_gen.go
@@ -9,13 +9,13 @@ package platform
 import (
 	"fmt"
 	"github.com/blackhorseya/godine/adapter/platform/handlers"
-	biz4 "github.com/blackhorseya/godine/app/domain/logistics/biz"
+	biz3 "github.com/blackhorseya/godine/app/domain/logistics/biz"
 	"github.com/blackhorseya/godine/app/domain/logistics/repo/delivery"
-	biz3 "github.com/blackhorseya/godine/app/domain/notification/biz"
+	biz2 "github.com/blackhorseya/godine/app/domain/notification/biz"
 	"github.com/blackhorseya/godine/app/domain/notification/repo/notification"
-	biz5 "github.com/blackhorseya/godine/app/domain/order/biz"
+	biz4 "github.com/blackhorseya/godine/app/domain/order/biz"
 	"github.com/blackhorseya/godine/app/domain/order/repo/order"
-	biz2 "github.com/blackhorseya/godine/app/domain/payment/biz"
+	"github.com/blackhorseya/godine/app/domain/payment"
 	"github.com/blackhorseya/godine/app/domain/restaurant"
 	"github.com/blackhorseya/godine/app/domain/user/biz"
 	"github.com/blackhorseya/godine/app/infra/authx"
@@ -25,12 +25,12 @@ import (
 	"github.com/blackhorseya/godine/app/infra/storage/mongodbx"
 	"github.com/blackhorseya/godine/app/infra/storage/postgresqlx"
 	"github.com/blackhorseya/godine/app/infra/transports/grpcx"
-	biz11 "github.com/blackhorseya/godine/entity/domain/logistics/biz"
-	biz9 "github.com/blackhorseya/godine/entity/domain/notification/biz"
-	biz10 "github.com/blackhorseya/godine/entity/domain/order/biz"
-	biz8 "github.com/blackhorseya/godine/entity/domain/payment/biz"
-	biz7 "github.com/blackhorseya/godine/entity/domain/restaurant/biz"
-	biz6 "github.com/blackhorseya/godine/entity/domain/user/biz"
+	biz10 "github.com/blackhorseya/godine/entity/domain/logistics/biz"
+	biz8 "github.com/blackhorseya/godine/entity/domain/notification/biz"
+	biz9 "github.com/blackhorseya/godine/entity/domain/order/biz"
+	biz7 "github.com/blackhorseya/godine/entity/domain/payment/biz"
+	biz6 "github.com/blackhorseya/godine/entity/domain/restaurant/biz"
+	biz5 "github.com/blackhorseya/godine/entity/domain/user/biz"
 	"github.com/blackhorseya/godine/pkg/adapterx"
 	"github.com/blackhorseya/godine/pkg/contextx"
 	"github.com/spf13/viper"
@@ -79,9 +79,9 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	restaurantServiceServer := restaurant.NewRestaurantService(iRestaurantRepo)
 	menuServiceServer := restaurant.NewMenuService(iRestaurantRepo)
 	iPaymentRepo := mongodbx.NewPaymentRepo(mongoClient)
-	paymentServiceServer := biz2.NewPaymentService(iPaymentRepo)
+	paymentServiceServer := payment.NewPaymentService(iPaymentRepo)
 	iNotificationRepo := notification.NewMongodb(mongoClient)
-	notificationServiceServer := biz3.NewNotificationService(iNotificationRepo)
+	notificationServiceServer := biz2.NewNotificationService(iNotificationRepo)
 	db, err := postgresqlx.NewClient(application)
 	if err != nil {
 		return nil, err
@@ -102,21 +102,21 @@ func New(v *viper.Viper) (adapterx.Restful, error) {
 	if err != nil {
 		return nil, err
 	}
-	notificationServiceClient, err := biz3.NewNotificationServiceClient(client)
+	notificationServiceClient, err := biz2.NewNotificationServiceClient(client)
 	if err != nil {
 		return nil, err
 	}
-	paymentServiceClient, err := biz2.NewPaymentServiceClient(client)
+	paymentServiceClient, err := payment.NewPaymentServiceClient(client)
 	if err != nil {
 		return nil, err
 	}
-	logisticsServiceClient, err := biz4.NewLogisticsServiceClient(client)
+	logisticsServiceClient, err := biz3.NewLogisticsServiceClient(client)
 	if err != nil {
 		return nil, err
 	}
-	orderServiceServer := biz5.NewOrderService(iOrderRepo, restaurantServiceClient, menuServiceClient, accountServiceClient, notificationServiceClient, paymentServiceClient, logisticsServiceClient)
+	orderServiceServer := biz4.NewOrderService(iOrderRepo, restaurantServiceClient, menuServiceClient, accountServiceClient, notificationServiceClient, paymentServiceClient, logisticsServiceClient)
 	iDeliveryRepo := delivery.NewMongodb(mongoClient)
-	logisticsServiceServer := biz4.NewLogisticsService(iDeliveryRepo, notificationServiceClient)
+	logisticsServiceServer := biz3.NewLogisticsService(iDeliveryRepo, notificationServiceClient)
 	initServers := NewInitServersFn(accountServiceServer, restaurantServiceServer, menuServiceServer, paymentServiceServer, notificationServiceServer, orderServiceServer, logisticsServiceServer)
 	server, err := grpcx.NewServer(application, initServers, authxAuthx)
 	if err != nil {
@@ -132,25 +132,25 @@ const serverName = "platform"
 
 // NewInitServersFn creates and returns a new InitServers function.
 func NewInitServersFn(
-	accountServer biz6.AccountServiceServer,
-	restaurantServer biz7.RestaurantServiceServer,
-	menuServer biz7.MenuServiceServer,
-	paymentServer biz8.PaymentServiceServer,
-	notifyServer biz9.NotificationServiceServer,
-	orderServer biz10.OrderServiceServer,
-	logisticsServer biz11.LogisticsServiceServer,
+	accountServer biz5.AccountServiceServer,
+	restaurantServer biz6.RestaurantServiceServer,
+	menuServer biz6.MenuServiceServer,
+	paymentServer biz7.PaymentServiceServer,
+	notifyServer biz8.NotificationServiceServer,
+	orderServer biz9.OrderServiceServer,
+	logisticsServer biz10.LogisticsServiceServer,
 ) grpcx.InitServers {
 	return func(s *grpc.Server) {
 		healthServer := health.NewServer()
 		grpc_health_v1.RegisterHealthServer(s, healthServer)
 		healthServer.SetServingStatus(serverName, grpc_health_v1.HealthCheckResponse_SERVING)
-		biz6.RegisterAccountServiceServer(s, accountServer)
-		biz7.RegisterRestaurantServiceServer(s, restaurantServer)
-		biz7.RegisterMenuServiceServer(s, menuServer)
-		biz8.RegisterPaymentServiceServer(s, paymentServer)
-		biz9.RegisterNotificationServiceServer(s, notifyServer)
-		biz10.RegisterOrderServiceServer(s, orderServer)
-		biz11.RegisterLogisticsServiceServer(s, logisticsServer)
+		biz5.RegisterAccountServiceServer(s, accountServer)
+		biz6.RegisterRestaurantServiceServer(s, restaurantServer)
+		biz6.RegisterMenuServiceServer(s, menuServer)
+		biz7.RegisterPaymentServiceServer(s, paymentServer)
+		biz8.RegisterNotificationServiceServer(s, notifyServer)
+		biz9.RegisterOrderServiceServer(s, orderServer)
+		biz10.RegisterLogisticsServiceServer(s, logisticsServer)
 		reflection.Register(s)
 	}
 }

--- a/app/domain/payment/BUILD.bazel
+++ b/app/domain/payment/BUILD.bazel
@@ -1,13 +1,13 @@
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "biz",
+    name = "payment",
     srcs = [
         "payment_grpc_client.go",
         "payment_grpc_server.go",
         "wire.go",
     ],
-    importpath = "github.com/blackhorseya/godine/app/domain/payment/biz",
+    importpath = "github.com/blackhorseya/godine/app/domain/payment",
     visibility = ["//visibility:public"],
     deps = [
         "//app/infra/otelx",

--- a/app/domain/payment/payment_grpc_client.go
+++ b/app/domain/payment/payment_grpc_client.go
@@ -1,4 +1,4 @@
-package biz
+package payment
 
 import (
 	"fmt"

--- a/app/domain/payment/payment_grpc_server.go
+++ b/app/domain/payment/payment_grpc_server.go
@@ -1,4 +1,4 @@
-package biz
+package payment
 
 import (
 	"context"

--- a/app/domain/payment/wire.go
+++ b/app/domain/payment/wire.go
@@ -1,4 +1,4 @@
-package biz
+package payment
 
 import (
 	"github.com/blackhorseya/godine/app/infra/storage/mongodbx"


### PR DESCRIPTION
- Update the import path from `biz` to `payment` in `app/domain/payment/BUILD.bazel`
- Rename the package `biz` to `payment` in files related to payment gRPC client and server
- Update the import path from `biz` to `payment` in `app/domain/payment/biz/payment_grpc_client.go`
- Rename the package `biz` to `payment` in `app/domain/payment/payment_grpc_server.go`
- Rename the package `biz` to `payment` in `app/domain/payment/wire.go`