### PR TITLE
refactor: refactor context handling for server interceptors

### DIFF
--- a/app/infra/transports/grpcx/server.go
+++ b/app/infra/transports/grpcx/server.go
@@ -33,14 +33,12 @@ func NewServer(app *configx.Application, init InitServers, authx *authx.Authx) (
 			grpc_ctxtags.UnaryServerInterceptor(),
 			grpc_zap.UnaryServerInterceptor(logger),
 			grpc_recovery.UnaryServerInterceptor(),
-			contextx.UnaryServerInterceptor(),
 			authx.UnaryServerInterceptor(),
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_ctxtags.StreamServerInterceptor(),
 			grpc_zap.StreamServerInterceptor(logger),
 			grpc_recovery.StreamServerInterceptor(),
-			contextx.StreamServerInterceptor(),
 			authx.StreamServerInterceptor(),
 		)),
 	)

--- a/entity/domain/user/model/user.go
+++ b/entity/domain/user/model/user.go
@@ -5,24 +5,13 @@ import (
 	"errors"
 
 	"github.com/blackhorseya/godine/pkg/contextx"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// NewUser creates and returns a new user.
-func NewUser(name, email, password string, address *Address) *Account {
-	return &Account{
-		Id:          "",
-		Username:    "",
-		Email:       email,
-		Password:    password,
-		Address:     address,
-		IsActive:    true,
-		Level:       0,
-		Roles:       nil,
-		SocialIDMap: nil,
-		CreatedAt:   timestamppb.Now(),
-		UpdatedAt:   timestamppb.Now(),
-	}
+type keyHandler struct{}
+
+// SetInContext sets the user in the context.
+func (x *Account) SetInContext(c context.Context) context.Context {
+	return context.WithValue(c, keyHandler{}, x)
 }
 
 // FromContextLegacy extracts the user from the context.
@@ -37,7 +26,7 @@ func FromContextLegacy(ctx contextx.Contextx) (*Account, error) {
 
 // FromContext extracts the user from the context.
 func FromContext(c context.Context) (*Account, error) {
-	account, ok := c.Value(Account{}).(*Account)
+	account, ok := c.Value(keyHandler{}).(*Account)
 	if !ok {
 		return nil, errors.New("no user found in context")
 	}


### PR DESCRIPTION
- Refactor `notificationService` ListMyNotifications method
- Update context handling in `notificationService` to use `next` context
- Modify context handling in `Authx` middleware for unary server interceptor
- Update context handling in `Authx` middleware for stream server interceptor
- Remove `contextx` from the list of unary server interceptors in `grpcx/server.go`
- Refactor context handling in `entity/domain/user/model/user.go` to use a custom keyHandler